### PR TITLE
Unlink react-native-ble-plx

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -181,7 +181,6 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
-    implementation project(':react-native-ble-plx')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
 

--- a/android/app/src/main/java/com/blediscoveryapp/MainApplication.java
+++ b/android/app/src/main/java/com/blediscoveryapp/MainApplication.java
@@ -4,7 +4,6 @@ import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
-import com.polidea.reactnativeble.BlePackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,3 @@
 rootProject.name = 'BLEDiscoveryApp'
-include ':react-native-ble-plx'
-project(':react-native-ble-plx').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-ble-plx/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,7 +34,6 @@ target 'BLEDiscoveryApp' do
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
   
-  pod 'react-native-ble-plx', :path => '../node_modules/react-native-ble-plx'
   pod 'react-native-ble-plx-swift', :path => '../node_modules/react-native-ble-plx'
 
   target 'BLEDiscoveryAppTests' do


### PR DESCRIPTION
When I run `run-ios` I get:

```
error React Native CLI uses autolinking for native dependencies, but the following modules are linked manually: 
  - react-native-ble-plx (to unlink run: "react-native unlink react-native-ble-plx")
```

So I ran the unlink command above :)

For more refenence:
https://github.com/react-native-community/cli/blob/master/docs/autolinking.md